### PR TITLE
Render WP2 apps metadata in the marketplace

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,6 +26,12 @@ pipeline {
             }
         }
 
+        stage('Generate markdown from applications metadata') {
+            steps {
+				iterateOverProjects()
+            }
+        }
+
         stage('Generate and publish Pelican site to Github Pages') {
             when {
                 anyOf {
@@ -39,6 +45,48 @@ pipeline {
                     sh 'git remote set-url origin "https://indigobot:${GITHUB_TOKEN}@github.com/deephdc/deephdc.github.io"'
                     sh 'make github'
                 }
+            }
+        }
+    }
+}
+
+void iterateOverProjects() {
+    data = readYaml (file: 'project_apps.yml')
+    data.each {
+        repo_name = sh(returnStdout: true, script: "basename ${it.module}")
+        repo_name = repo_name.trim()
+        repo_dir = "/tmp/${repo_name}"
+                            
+        script {
+            try {
+                stage("Application: ${repo_name}") {
+                    checkout([  
+                        $class: 'GitSCM', 
+                        branches: [[name: "refs/heads/master"]], 
+                        doGenerateSubmoduleConfigurations: false, 
+                        extensions: [[
+                            $class: 'RelativeTargetDirectory',
+                            relativeTargetDir: repo_dir
+                        ]],
+                        submoduleCfg: [], 
+                        userRemoteConfigs: [[url: it.module]],
+                    ])
+                    dir(repo_dir) {
+                        // TEST: Validate metadata according to DEEP schema
+                        sh 'deep-app-schema-validator metadata.json'
+                        // TEST: Search for non-ascii characters
+                        sh 'python -c "open(\'metadata.json\').read().encode(\'ascii\')"'
+                
+                        // Generate markdown file from metadata
+                        def markdown_file = [repo_name, 'md'].join('.').toLowerCase()
+                        sh "${WORKSPACE}/deephdc.github.io/metadata2md.py metadata.json --output-file ${WORKSPACE}/deephdc.github.io/content/modules/${markdown_file}"
+                    }
+                }
+            }
+            catch(e) {
+                // Continue even if it fails
+                env.pipeline_status = 'UNSTABLE'
+                currentBuild.result = 'SUCCESS'
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,6 +27,9 @@ pipeline {
         }
 
         stage('Generate markdown from applications metadata') {
+            when {
+                branch 'pelican'
+            }
             steps {
                 iterateOverProjects()
                 sh 'git status --porcelain=v1'
@@ -35,9 +38,7 @@ pipeline {
 
         stage('Generate and publish Pelican site to Github Pages') {
             when {
-                anyOf {
-                    branch 'pelican'
-                }
+                branch 'pelican'
             }
             steps {
                 withCredentials([string(
@@ -87,7 +88,6 @@ void iterateOverProjects() {
             }
             catch(e) {
                 // Continue even if it fails
-                env.pipeline_status = 'UNSTABLE'
                 currentBuild.result = 'SUCCESS'
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,6 +29,7 @@ pipeline {
         stage('Generate markdown from applications metadata') {
             steps {
 				iterateOverProjects()
+                sh 'git status --porcelain=v1'
             }
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
 
         stage('Generate markdown from applications metadata') {
             steps {
-				iterateOverProjects()
+                iterateOverProjects()
                 sh 'git status --porcelain=v1'
             }
         }
@@ -40,8 +40,9 @@ pipeline {
                 }
             }
             steps {
-                withCredentials([string(credentialsId: "indigobot-github-token",
-                                 variable: "GITHUB_TOKEN")]) {
+                withCredentials([string(
+                        credentialsId: "indigobot-github-token",
+                        variable: "GITHUB_TOKEN")]) {
                     sh 'git fetch origin master:master -f'
                     sh 'git remote set-url origin "https://indigobot:${GITHUB_TOKEN}@github.com/deephdc/deephdc.github.io"'
                     sh 'make github'

--- a/metadata2md.py
+++ b/metadata2md.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+
+import argparse
+from datetime import datetime
+import os
+
+from jinja2 import Environment, BaseLoader
+import simplejson as json
+
+
+TEMPLATE = '''
+---
+Title: {{ title }}
+Date: {{ date_creation }}
+Modified: {{ date_modification }}
+Category: {{ keywords }}
+GitHub: {{ sources.code }}
+DockerHub: {{ sources.docker_registry_repo }}
+Training_files: {{ training_files_url | default('NA') }}
+License: {{ license }}
+Summary: {{ summary }}
+---
+{% if continuous_integration is defined %}
+[![Build Status]({{ continuous_integration.build_status_badge }})](continuous_integration.build_status_url)
+{% endif %}
+
+{{ description | join('\n') }}
+{% if description_references is defined %}
+**References**"
+{{ description_references }}
+{% endif %}
+'''
+
+def main():
+    parser = argparse.ArgumentParser(description=('Render DEEP application '
+                                                  'metadata as Pelican '
+                                                  'markdown document.'))
+    parser.add_argument('metadata',
+                        metavar='METADATA_JSON_FILE',
+                        type=argparse.FileType('r'),
+                        help='DEEP application metadata')
+    parser.add_argument('--output-file',
+                        metavar='MARKDOWN_FILE',
+                        type=argparse.FileType('w'),
+                        help='Target markdown file')
+    args = parser.parse_args()
+
+    json_data = json.load(args.metadata)
+    mtime = os.stat(args.metadata.name).st_mtime
+    mtime_str = datetime.fromtimestamp(mtime).strftime('%Y-%m-%d %H:%M:%S')
+    json_data['date_modification'] = mtime_str
+
+    jinja_env = Environment(loader=BaseLoader()).from_string(TEMPLATE)
+    md_data = jinja_env.render(json_data)
+    if args.output_file:
+        args.output_file.write(md_data)
+    else:
+        print(md_data)
+
+if __name__ == "__main__":
+    main()

--- a/project_apps.yml
+++ b/project_apps.yml
@@ -1,3 +1,14 @@
 ---
-- module: https://github.com/deephdc/DEEP-OC-mods
 - module: https://github.com/deephdc/DEEP-OC-dogs_breed_det
+- module: https://github.com/deephdc/DEEP-OC-mods
+- module: https://github.com/deephdc/DEEP-OC-conus-classification
+- module: https://github.com/deephdc/DEEP-OC-conus-classification-tf
+- module: https://github.com/deephdc/DEEP-OC-generic-container 
+- module: https://github.com/deephdc/DEEP-OC-image-classification-tf
+- module: https://github.com/deephdc/DEEP-OC-phytoplankton-classification
+- module: https://github.com/deephdc/DEEP-OC-phytoplankton-classification-tf
+- module: https://github.com/deephdc/DEEP-OC-plant-classification-theano
+- module: https://github.com/deephdc/DEEP-OC-plants-classification-tf
+- module: https://github.com/deephdc/DEEP-OC-retinopathy_test
+- module: https://github.com/deephdc/DEEP-OC-seeds-classification
+- module: https://github.com/deephdc/DEEP-OC-seeds-classification-tf

--- a/project_apps.yml
+++ b/project_apps.yml
@@ -1,0 +1,3 @@
+---
+- module: https://github.com/deephdc/DEEP-OC-mods
+- module: https://github.com/deephdc/DEEP-OC-dogs_breed_det

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,6 @@ pelican>=4.0.1
 ghp-import>=0.5.5
 Markdown>=3.0.1
 PyYAML>=3.13
+git+https://github.com/deephdc/schema4apps
+simplejson
+jinja2


### PR DESCRIPTION
Automatically render metadata descriptions from DEEP-OC repositories (such as [1]) in the marketplace.
- File `project_apps.yml` contains the list of applications being considered
- File `metadata2md.py` renders markdown text from DEEP metadata

The pipeline loops over the list of applications, fetching the code to obtain the markdown file. Any change triggers marketplace re-creation.

[1] https://github.com/deephdc/DEEP-OC-mods/blob/master/metadata.json