### PR TITLE
add audio classification

### DIFF
--- a/project_apps.yml
+++ b/project_apps.yml
@@ -10,3 +10,4 @@
 - module: https://github.com/deephdc/DEEP-OC-satsr 
 - module: https://github.com/deephdc/DEEP-OC-speech-to-text-tf
 - module: https://github.com/deephdc/DEEP-OC-posenet-tf
+- module: https://github.com/deephdc/DEEP-OC-audio-classification-tf


### PR DESCRIPTION
This is a PR to merge the `audio-classication-tf` module. For the time being only the `predict` method is available. I will work on the `training` as soon as possible.

A minor issue I have detected is that sometimes the Docker build fails randomly. It seems to be related to the files (weights and so on) that are downloaded from the IFCA Cloud Object Store. When it fails it is usually because it finds that the data are corrupt. But if you run it another time it might download them fine. 

I believe I can have some relation with the additional compression of the files performed when uploading to the Cloud (for example my `tar.gz` is 10MB ligther in the Object Store than in my computer). Maybe this additional compression (sometimes?) corrupts the data? I don't know, it's strange, I only found this to be an issue in this module. I'll look into it whenever I can. 

To be fair the Docker build works just fine **most** of the time.