### PR TITLE
Fix modules slug

### DIFF
--- a/metadata2md.py
+++ b/metadata2md.py
@@ -27,6 +27,7 @@ Dataset: {{ dataset_url }}
 {% endif %}
 License: {{ license }}
 Summary: {{ summary }}
+Slug: {{sources.docker_registry_repo.split("/")[1].replace("_", "-")}}
 ---
 {% if continuous_integration is defined %}
 [![Build Status]({{ continuous_integration.build_status_badge }})]({{ continuous_integration.build_status_url }})


### PR DESCRIPTION
Replace slug (module page title) with a consistent unique name (dockerhub repo name).
Underscores have been replaced with hyphens following [this](https://www.ecreativeim.com/blog/index.php/2011/03/30/seo-basics-hyphen-or-underscore-for-seo-urls/).

Name also matches the one of the dashboard.
Marketplace:
https://marketplace.deep-hybrid-datacloud.eu/modules/deep-oc-audio-classification-tf.html
Dashboard:
https://train.deep-hybrid-datacloud.eu/module/deep-oc-audio-classification-tf